### PR TITLE
Recursive network support + Smarter network call processing

### DIFF
--- a/CreateNode.js
+++ b/CreateNode.js
@@ -165,6 +165,32 @@ function createStandardNode(type="", coords=null, node_data=null, standards=null
             }, null, coords);
         n.input_elements["input" + 0 + "input"].checked = standards.value0;
         n.input_elements["input" + 1 + "input"].checked = standards.value1;
+    } else if (type=="nand") {
+        if (standards.value0 == null) {standards.value0 = false};
+        if (standards.value1 == null) {standards.value1 = false};
+        var n = new Node("Nand", "#aaa", [["boolean", "input A", true],["boolean", "input B", true]], [["boolean", "output"]], `
+        <svg width="150" height="60" version="1.1" viewBox="0 0 141.11 50.8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <g transform="matrix(.29505 0 0 .30394 -3.0609 -2.4078)">
+         <g font-family="Verdana" stroke-width="1px">
+          <text x="9" y="77.173828" fill="#ffffff" style="line-height:0%" xml:space="preserve"><tspan x="9" y="77.173828" fill="#ffffff" font-size="72px" style="line-height:1.25">A</tspan></text>
+          <text x="9" y="155.17383" fill="#fffffc" style="line-height:0%" xml:space="preserve"><tspan x="9" y="155.17383" fill="#fffffc" font-size="72px" style="line-height:1.25">B</tspan></text>
+          <path id="path1316" d="m72 51h113" fill="none" stroke="#fff" stroke-linecap="round" stroke-width="7.5"/>
+         </g>
+         <use transform="translate(0,78)" width="500" height="180" xlink:href="#path1316"/>
+         <use transform="translate(196.58 39)" width="500" height="180" fill="none" stroke="#ffffff" xlink:href="#path1316"/>
+         <g>
+          <path d="m207 171-71.3-6e-5v-158.5l71.76-2.6e-5c38.898-2.5e-5 70.84 35.504 70.84 79.25s-31.942 79.25-71.3 79.25z" fill-rule="evenodd" stroke="#fff" stroke-linejoin="round" stroke-width="7.5"/>
+          <text x="395.41205" y="109.23633" fill="#fffffe" font-family="Verdana" stroke-width="1px" style="line-height:0%" xml:space="preserve"><tspan x="395.41205" y="109.23633" fill="#fffffe" font-size="56px" style="line-height:1.25">out</tspan></text>
+          <circle transform="translate(12.91 -.35353)" cx="285.32" cy="89.844" r="20.153" fill="#fff" fill-rule="evenodd" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="7.5"/>
+         </g>
+        </g>
+       </svg>
+       `,
+            behaviour=function(input_data) {
+                return([!(input_data[0] && input_data[1] )]);
+            }, null, coords);
+        n.input_elements["input" + 0 + "input"].checked = standards.value0;
+        n.input_elements["input" + 1 + "input"].checked = standards.value1;
     } else if (type == "compare") {
         if (standards.value0 == null) {standards.value0 = 0};
         if (standards.value1 == null) {standards.value1 = 0};

--- a/CreateNode.js
+++ b/CreateNode.js
@@ -770,7 +770,6 @@ function loadFile(datastr) {
     EmptyWorkspace(); //Start the new file with an empty workspace
 
     var datastr = datastr.split("\n").slice(1).join("\n");
-    console.log(datastr);
     var saveobject = JSON.parse(datastr);
     try {
         live_data_nodes_update = saveobject.settings.live_data_nodes_update;

--- a/CreateNode.js
+++ b/CreateNode.js
@@ -792,12 +792,13 @@ function loadFile(datastr) {
     }
 
 
-    for (let x of all_nodes) {
-        x.getConnectorPositions();
+    for (let node of all_nodes) {
+        node.getConnectorPositions();
     }
 
     for (let node of all_nodes) {
         node.drawInputConnectorLines();
+        node.updateIsRecursive()
     }
 }
 

--- a/CreateNode.js
+++ b/CreateNode.js
@@ -685,13 +685,16 @@ function createStandardNode(type="", coords=null, node_data=null, standards=null
     }
 
     n.type = type.toLowerCase();
+    if (node_data.previous_tick_calloutput != null) {
+        n.previous_tick_calloutput = node_data.previous_tick_calloutput;
+    }
 }
 
 
 
 
 
-Logics_version = 1.4;
+Logics_version = "v2.0.0";
 project_name = "Logics project";
 
 function makeFile() {
@@ -754,6 +757,7 @@ function makeFile() {
         node_save.coords = [node.node_container.style.left,node.node_container.style.top];
         node_save.node_data = node.node_data;
         node_save.id = x; //ID used for identifiing the node while reconstructing the network.
+        node_save.previous_tick_calloutput = node.previous_tick_calloutput;
         saveobject.nodes.push(node_save);
     }
     var textsave = text+JSON.stringify(saveobject);
@@ -792,11 +796,25 @@ function loadFile(datastr) {
             standards["value"+inpn] = inp;
         }
 
-        if (saveobject.version < 1.2) {
-            node.coords[0] = parseInt(node.coords[0].replace("px", ""))+9000+"px";
-            node.coords[1] = parseInt(node.coords[1].replace("px", ""))+5000+"px";
-            console.log("This is an old document. Changes have been made while loading. If you save the file. it will be updated.");
+        if (typeof saveobject.version == "number") {
+            if (saveobject.version < 1.2) {
+                node.coords[0] = parseInt(node.coords[0].replace("px", ""))+9000+"px";
+                node.coords[1] = parseInt(node.coords[1].replace("px", ""))+5000+"px";
+                console.log("This is an old document. Changes have been made while loading. If you save the file, it will be updated.");
+            }
+        } else {
+            {
+                let versionstr = saveobject.version.substring(1);
+                let versionlist = versionstr.split(".");
+                var release_major = versionlist[0];
+                var release_minor = versionlist[1];
+                var release_patch = versionlist[2];
+            }
         }
+        if (release_major >= 2) {
+            node.node_data.previous_tick_calloutput = node.previous_tick_calloutput;
+        }
+        
 
         createStandardNode(node.type, node.coords, node.node_data, standards) //type, coords, data, standards;
     }

--- a/CreateNode.js
+++ b/CreateNode.js
@@ -810,9 +810,7 @@ function loadFile(datastr) {
                 var release_patch = versionlist[2];
             }
         }
-        if (release_major >= 2) {
-            node.node_data.previous_tick_calloutput = node.previous_tick_calloutput;
-        }
+        
         
 
         createStandardNode(node.type, node.coords, node.node_data, standards) //type, coords, data, standards;
@@ -831,6 +829,9 @@ function loadFile(datastr) {
                 }              
             }
         }
+        if (release_major >= 2) {
+            node.previous_tick_calloutput = nodedatafromsave.previous_tick_calloutput;
+        }
 
     }
 
@@ -842,6 +843,7 @@ function loadFile(datastr) {
     for (let node of all_nodes) {
         node.drawInputConnectorLines();
         node.updateIsRecursive()
+        node.update();
     }
 }
 

--- a/Nodelib.js
+++ b/Nodelib.js
@@ -497,13 +497,14 @@ class Node {
                         if (remove_outputcoordsdependant_node) {connectiontoremove[3].outputcoords_dependant_nodes.splice(connectiontoremove[3].outputcoords_dependant_nodes.indexOf(connectiontoremove[3]))}
                         
                     }
-
+                    this.updateIsRecursive();
+                    this.getInputData(); //To make sure the connectors become green when recursive
                     break;
                 };
             }
         }
 
-        this.updateIsRecursive();
+        
 
     }
 
@@ -584,18 +585,10 @@ class Node {
                 }
                 if (this.recursive && this.input_connections[x][3].recursive) {
                     if (connectorVisualisation) {
-                        if (data) {
-                            this.connector_lines[x].style['stroke-width'] = 4;
-                            this.connector_lines[x].style['stroke'] = "#0f0";
-                            if (connectorglow)
-                                this.connector_lines[x].setAttribute("filter", "url(#glowconnector)");
-                            else
-                                this.connector_lines[x].setAttribute("filter", "");
-                        } else {
-                            this.connector_lines[x].style['stroke-width'] = 2;
-                            this.connector_lines[x].style['stroke'] = "#0a0";
-                            this.connector_lines[x].setAttribute("filter", "");
-                        }
+                        this.connector_lines[x].style['stroke-width'] = 2;
+                        this.connector_lines[x].style['stroke'] = "#0f0";
+                        this.connector_lines[x].setAttribute("filter", "");
+                        
                     }
                 } else {
                     if (connectorVisualisation) {
@@ -881,6 +874,9 @@ window.setInterval(function () {
                     x.update();
                 }
             }
+            var nodedatabackup = []
+            var recursive_nodes_to_calculate_backup = recursive_nodes_to_calculate;
+            recursive_nodes_to_calculate = recursive_nodes_to_calculate_backup;
         }
     }
 

--- a/Nodelib.js
+++ b/Nodelib.js
@@ -132,6 +132,7 @@ class Node {
         this.current_tick_calloutput = {}; //Stores the outcome of the network for this node in the current "tick", so that 10 output nodes connected to one node with a node network before it, don't all call the whole network.
         this.previous_tick_calloutput = {}; //For recursive networks
         this.previous_tick = current_tick;
+        this.recursive = false;
 
 
 
@@ -502,12 +503,7 @@ class Node {
             }
         }
 
-        
-        
-
         this.updateIsRecursive();
-        /*console.log(this.recursive);
-        console.log(this.outputcoords_dependant_nodes);*/
 
     }
 
@@ -560,11 +556,13 @@ class Node {
 
     getInputData() {
         var inpdatalist = []
+        
         for (var x in this.inputs) {
             if (x in this.input_connections) {
-
-                if (!this.recursive) {
+                
+                if (this.recursive == false) {
                     var data = this.input_connections[x][3].getNodeOutput()[this.input_connections[x][0]];
+                    
                 } else {
                     let childnodespreviousoutput = this.input_connections[x][3].previous_tick_calloutput[current_network_call];
 
@@ -615,7 +613,6 @@ class Node {
                         }
                     }
                 }
-
                 
 
 
@@ -858,7 +855,7 @@ live_data_nodes = [];
 
 
 
-
+intervalcounter = 0;
 window.setInterval(function () {
     current_tick = !current_tick;
     for (x of output_nodes) {
@@ -869,24 +866,29 @@ window.setInterval(function () {
         x.getNodeOutput();
         recursive_nodes_to_calculate.splice(recursive_nodes_to_calculate.indexOf(x), 1);
     }
-}, 10);
-window.setInterval(function () {
-    if (live_data_nodes_update) {
-        for (let x of live_data_nodes) {
-            x.update();
-        }
-    }
-}, 500);
 
-window.setInterval(function () {
-    if (connectorVisualisation) {
-        for (let x of all_nodes) {
-            if (x.outputcoords_dependant_nodes.length == 0 | x.recursive) {
+    if (intervalcounter%50 == 0) {
+        if (live_data_nodes_update) {
+            for (let x of live_data_nodes) {
                 x.update();
             }
         }
     }
-}, 100);
+    if (intervalcounter%10 ==0) {
+        if (connectorVisualisation) {
+            for (let x of all_nodes) {
+                if (x.outputcoords_dependant_nodes.length == 0) {
+                    x.update();
+                }
+            }
+        }
+    }
+
+    if (intervalcounter/1000 > 1) {
+        intervalcounter = 0
+    }
+}, 10);
+
 
 function uniq(a) {
     var prims = {"boolean":{}, "number":{}, "string":{}}, objs = [];

--- a/Nodelib.js
+++ b/Nodelib.js
@@ -504,7 +504,7 @@ class Node {
                                 remove_outputcoordsdependant_node = false;
                             }
                         }
-                        if (remove_outputcoordsdependant_node) {connectiontoremove[3].outputcoords_dependant_nodes.splice(connectiontoremove[3].outputcoords_dependant_nodes.indexOf(c[2]))}
+                        if (remove_outputcoordsdependant_node) {connectiontoremove[3].outputcoords_dependant_nodes.splice(connectiontoremove[3].outputcoords_dependant_nodes.indexOf(c[2]), 1)}
                         
                     }
                     this.updateIsRecursive();

--- a/Nodelib.js
+++ b/Nodelib.js
@@ -504,7 +504,7 @@ class Node {
                                 remove_outputcoordsdependant_node = false;
                             }
                         }
-                        if (remove_outputcoordsdependant_node) {connectiontoremove[3].outputcoords_dependant_nodes.splice(connectiontoremove[3].outputcoords_dependant_nodes.indexOf(connectiontoremove[3]))}
+                        if (remove_outputcoordsdependant_node) {connectiontoremove[3].outputcoords_dependant_nodes.splice(connectiontoremove[3].outputcoords_dependant_nodes.indexOf(c[2]))}
                         
                     }
                     this.updateIsRecursive();

--- a/Nodelib.js
+++ b/Nodelib.js
@@ -927,6 +927,8 @@ function EmptyWorkspace() { //To delete all nodes and reset values.
     all_nodes = [];
     z_index_id = 0;
     node_id = 0;
+    recursive_nodes_to_calculate_working = [];
+    recursive_nodes_to_calculate = [];
     
 }
 

--- a/Nodelib.js
+++ b/Nodelib.js
@@ -18,6 +18,8 @@ zoom_factor = 1;
 current_network_call = "main"; //Multiple network states call states will be introduced in the future.
 current_tick = 0;
 
+debug_mode = true;
+
 
 { /*Made by Thijmen Voskuilen. See the about tab on this webpage for contact info.*/
     let width = 15;
@@ -58,6 +60,7 @@ class Node {
         this.html = customHTML;
         this.titlecolor = titlecolor;
         this.title = title;
+        if (debug_mode) {this.title = title+": "+this.id}
         this.inputs = inputs;
         this.outputs = outputs;
         if (behaviour != null) {
@@ -498,7 +501,7 @@ class Node {
                         
                     }
                     this.updateIsRecursive();
-                    this.getInputData(); //To make sure the connectors become green when recursive
+                    c[2].getInputData(); //To make sure the connectors become green when recursive
                     break;
                 };
             }
@@ -561,7 +564,7 @@ class Node {
         for (var x in this.inputs) {
             if (x in this.input_connections) {
                 
-                if (this.recursive == false) {
+                if (!this.recursive) {
                     var data = this.input_connections[x][3].getNodeOutput()[this.input_connections[x][0]];
                     
                 } else {
@@ -857,8 +860,8 @@ window.setInterval(function () {
     recursive_nodes_to_calculate = uniq(recursive_nodes_to_calculate);
     for (x of recursive_nodes_to_calculate) {
         x.getNodeOutput();
-        recursive_nodes_to_calculate.splice(recursive_nodes_to_calculate.indexOf(x), 1);
     }
+    
 
     if (intervalcounter%50 == 0) {
         if (live_data_nodes_update) {

--- a/Nodelib.js
+++ b/Nodelib.js
@@ -292,6 +292,13 @@ class Node {
             x.childNodeDeleted(this);
         }
 
+        for (x in this.input_connections) {
+            this.input_connections[x][3].outputcoords_dependant_nodes.splice(this.input_connections[x][3].outputcoords_dependant_nodes.indexOf(this), 1)
+        }
+        for (x in this.input_connections) {
+            this.input_connections[x][3].updateIsRecursive();
+        }
+
         if (output_nodes.includes(this)) {
             output_nodes.splice(output_nodes.indexOf(this), 1);
         }

--- a/Nodelib.js
+++ b/Nodelib.js
@@ -292,18 +292,27 @@ class Node {
             x.childNodeDeleted(this);
         }
 
-        for (x in this.input_connections) {
+        for (let x in this.input_connections) {
             this.input_connections[x][3].outputcoords_dependant_nodes.splice(this.input_connections[x][3].outputcoords_dependant_nodes.indexOf(this), 1)
         }
-        for (x in this.input_connections) {
+        for (let x in this.input_connections) {
             this.input_connections[x][3].updateIsRecursive();
         }
 
         if (output_nodes.includes(this)) {
             output_nodes.splice(output_nodes.indexOf(this), 1);
         }
+
+        if (recursive_nodes_to_calculate.includes(this)) {
+            recursive_nodes_to_calculate.splice(recursive_nodes_to_calculate.indexOf(this), 1);
+        }
+        if (recursive_nodes_to_calculate_working.includes(this)) {
+            recursive_nodes_to_calculate_working.splice(recursive_nodes_to_calculate_working.indexOf(this), 1);
+        }
+
         if ((! excludeallnodeslist) || typeof excludeallnodeslist != "boolean") {
             all_nodes.splice(all_nodes.indexOf(this), 1);
+            console.log("Node deleted");
         }
         if (live_data_nodes.includes(this)) {
             live_data_nodes.splice(live_data_nodes.indexOf(this), 1);
@@ -861,11 +870,12 @@ live_data_nodes = [];
 intervalcounter = 0;
 window.setInterval(function () {
     current_tick = !current_tick;
-    for (x of output_nodes) {
+    for (let x of output_nodes) {
         x.update();
     }
-    recursive_nodes_to_calculate = uniq(recursive_nodes_to_calculate);
-    for (x of recursive_nodes_to_calculate) {
+    recursive_nodes_to_calculate_working = uniq(recursive_nodes_to_calculate);
+    recursive_nodes_to_calculate = []; //The list is emptied so that the next tick starts without any update orders from the previous tick left.
+    for (x of recursive_nodes_to_calculate_working) {
         x.getNodeOutput();
     }
     

--- a/index.html
+++ b/index.html
@@ -311,6 +311,8 @@
 
         <a onclick='createStandardNode("xor")'>Logical xor gate</a>
 
+        <a onclick='createStandardNode("nand")'>Logical nand gate</a>
+
         <h1>Number operations</h1>
         <a onclick='createStandardNode("compare")'>Compare</a>
 


### PR DESCRIPTION
## Recursive networks
Previously, putting a node output into itself (directly or indirectly) would cause the program to keep calling itself and no answer would come out. In this branch, I worked on fixing that. Now, when you plug a node into itself or a place before it, the node will process the data it put into itself in the next tick, allowing for recursive networks. The connectors of connections in such a recursive network will turn green, to indicate that it is a recursive connection. 
Recursive nodes will allow for new possibilities, like t flipflops.

## Smarter network call processing
The problem the system had is that when you had a (large) network which combined into a single node with 100 lights connected to it, each light would call the **entire** network, which is very inefficiënt, as the output of that node for that frame had already been processed by the first node. Now, a node will remember its previous output for a tick, so that it can return the things it already has calculated instead of the whole network needing to be called.

## New versioning system
Logics versioning now follows a major.minor.patch system for versioning, instead of the major.minor system that didn't allow for more than 10 minor updates, including the x.0 version, because the version was described as a number instead of as a string.

## Nand node
A nand node has been added in this branch too.